### PR TITLE
fix footer links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,20 +51,20 @@ round-avatar: true
 # You can change the order that they show up on the page by changing the order here.
 # Uncomment the links you want to show and add your information to each one.
 social-network-links:
-  email: "luke.richardson-foulger@gmail.com.com"
+  email: luke.richardson-foulger@gmail.com
   rss: true  # remove this line if you don't want to show an RSS link at the bottom
-  facebook: https://www.facebook.com/profile.php?id=100010465969242
-  github: https://github.com/EkulRF
-  twitter: https://twitter.com/ObeyingMyBrain
+  facebook: profile.php?id=100010465969242
+  github: EkulRF
+  twitter: ObeyingMyBrain
 #  patreon: DeanAttali
 #  youtube: c/daattali
 #  medium: yourname
 #  reddit: yourname
-  linkedin: https://www.linkedin.com/in/luke-richardson-foulger/
+  linkedin: luke-richardson-foulger
 #  xing: yourname
 #  stackoverflow: "3943160/daattali"
 #  snapchat: deanat78
-  instagram: https://www.instagram.com/ekulrf/
+  instagram: ekulrf
 #  spotify: yourname
 #  telephone: +14159998888
 #  steam: deanat78
@@ -75,7 +75,7 @@ social-network-links:
 #  mastodon: instance.url/@username
 #  bluesky: yourname
   ORCID: 0009-0006-8496-8300
-  google-scholar: https://scholar.google.com/citations?user=kW4xHbcAAAAJ&hl=en
+  google-scholar: kW4xHbcAAAAJ&hl=en
 #  discord: "invite_code" or "users/userid" or "invite/invite_code" 
 #  kaggle: yourname
 #  hackerrank: yourname


### PR DESCRIPTION
footer links were broken.

items in [social-network-links.html](https://github.com/EkulRF/lukes-letters/blob/master/_includes/social-networks-links.html) already included the necessary pre-link stuff. Facebook for example

https://github.com/EkulRF/lukes-letters/blob/38ba5f51f4a2ec8cdcaaade45b329b5964a6d296/_includes/social-networks-links.html#L42-L52

Thus, with full URL in [config.yml](https://github.com/EkulRF/lukes-letters/blob/master/_config.yml),

https://github.com/EkulRF/lukes-letters/blob/38ba5f51f4a2ec8cdcaaade45b329b5964a6d296/_config.yml#L56

The link in the footer turns into

![image](https://github.com/EkulRF/lukes-letters/assets/13833017/aca2a3d0-1f35-41f0-8d51-d83226d81201)

fixed it for you, but only because issues are disabled in this repository. Otherwise I would've just created an issue and you could've fixed it yourself

:)